### PR TITLE
Define whether to update the APT cache per play.

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,7 +11,10 @@ Need ansible 2+
 Role Variables
 --------------
 
-
+* `packages_update_cache`: Defines if the APT cache should be updated. Defaults
+  to `no`.
+* `packages_cache_valid_time`: Defines for how long the APT cache should be
+  considered valid. Defaults to 3600 seconds.
 
 Dependencies
 ------------
@@ -25,7 +28,7 @@ Example Playbook
 - hosts: servers
   roles:
    - { role: SimpliField.packages, packages: [git] }
-   - { role: SimpliField.packages, packages: [{name: pymongo, state: present, update: true}] }
+   - { role: SimpliField.packages, packages: [{name: pymongo, state: present}], packages_update_cache: true }
 ```
 
 License

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,2 +1,3 @@
 ---
 packages: []
+packages_cache_valid_time: 3600

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -3,5 +3,6 @@
   apt:
     name: "{{ item.name | default(item)  }}"
     state: "{{ item.state | default(\"present\") }}"
-    update_cache: "{{ item.update | default(omit) }}"
+    update_cache: "{{ packages_update_cache | default(omit) }}"
+    cache_valid_time: "{{ packages_cache_valid_time }}"
   with_items: "{{ packages }}"


### PR DESCRIPTION
The current `packages` variable allows you to define an `update`
property per item (package), each will trigger an APT cache update.
Since the cache is reused for each package installed on the `with_items`
loop, it doesn't seem to make much sense to define it per package. For
this reason, I've added a `packages_update_cache` variable which defines
whether the cache should be updated before installing the packages.

I've also added a `packages_cache_valid_time` variable, which defaults
to 3600 seconds, so that the update doesn't run every single time this
role is executed.